### PR TITLE
Make sure valid URL is constructed

### DIFF
--- a/guided-trials-default-custom-user-data/maven-default-custom-user-data.groovy
+++ b/guided-trials-default-custom-user-data/maven-default-custom-user-data.groovy
@@ -141,9 +141,19 @@ String customValueSearchUrl(def api, Map<String, String> search) {
         "search.names=${encodeURL(name)}&search.values=${encodeURL(value)}"
     }.join('&')
 
-    "${api.server}/scans?$query"
+    def serverUrl = appendIfMissing(api.server, "/");
+
+    "${serverUrl}scans?$query"
 }
 
 String encodeURL(String url){
     URLEncoder.encode(url, 'UTF-8')
+}
+
+String appendIfMissing(String str, String suffix) {
+    if (str.endsWith(suffix)) {
+        return str
+    } else {
+        return str + suffix
+    }
 }


### PR DESCRIPTION
Several customers ran into the problem that the script created an
invalid query URL because they configured the Gradle Enterprise server
URL in gradle-enterprise.xml with a trailing slash. This cuased the
query URL to contain an additional slash after the server base URL which
does not work.
This fix simply makes sure that a slash is only added if it's not
already there.